### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(EXTENSION_HOMEPAGE "https://github.com/gaudot/SlicerDentalSegmentator")
 set(EXTENSION_CATEGORY "Segmentation")
 set(EXTENSION_CONTRIBUTORS "Gauthier DOT (AP-HP), Laurent GAJNY (ENSAM), Roman FENIOUX (KITWARE SAS), Thibault PELLETIER (KITWARE SAS)")
 set(EXTENSION_DESCRIPTION "Fully automatic AI segmentation tool for Dental CT and CBCT scans based on DentalSegmentator nnU-Net model.")
-set(EXTENSION_ICONURL "https://github.com/gaudot/SlicerDentalSegmentator/raw/main/DentalSegmentator/Resources/Icons/DentalSegmentator.png")
+set(EXTENSION_ICONURL "https://github.com/gaudot/SlicerDentalSegmentator/raw/main/DentalSegmentator/Resources/Icons/DentalSegmentator_full_icon.png")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/gaudot/SlicerDentalSegmentator/raw/main/Screenshots/1.png")
 set(EXTENSION_DEPENDS "NNUNet") # Specified as a list or "NA" if no dependencies
 


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.